### PR TITLE
Update Java 17 to Java 21 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 LABEL org.opencontainers.image.vendor="Dockcenter"
 LABEL org.opencontainers.image.title="Velocity"


### PR DESCRIPTION
Java 21 LTS is the most recent stable LTS version. It's recommended to move towards newer versions when available while the LTS versions guarantee support for an extended period of time.